### PR TITLE
FLOPPY: Migrate `BUILD_LOG` variable to `DO_BASHUP`

### DIFF
--- a/kernel_build/ckbuild.sh
+++ b/kernel_build/ckbuild.sh
@@ -84,9 +84,6 @@ USE_CCACHE=1
 DO_TAR=1
 DO_ZIP=1
 
-# Upload build log
-BUILD_LOG=1
-
 ## Info message
 LINKER="ld.lld"
 DEVICE="Exynos 1280 Family"

--- a/kernel_build/scripts/upload.sh
+++ b/kernel_build/scripts/upload.sh
@@ -28,17 +28,13 @@ upload() {
     cd "$KDIR"
 
     if [ "$DO_BASHUP" = "1" ]; then
-        echo -e "\nINFO: Uploading to bashupload.com\n"
+        echo -e "\nINFO: Uploading build and log to bashupload.com\n"
         curl -T "$ZIP_PATH" bashupload.com
+        curl -T log.txt bashupload.com
     fi
 
     if [ "$DO_TG" = "1" ]; then
         echo -e "\nINFO: Uploading to Telegram\n"
         tgs "$ZIP_PATH"
-    fi
-
-    if [ "$BUILD_LOG" = "1" ]; then
-        echo -e "\nINFO: Uploading log to bashupload.com\n"
-        curl -T log.txt bashupload.com
     fi
 }


### PR DESCRIPTION
Because `BUILD_LOG` variable was unconditionally set to `1`, logs would always upload to bashup. However, some countries don't have access to that website without use of proxies/VPNs. We could also just tie `BUILD_LOG` variable to a new parameter (Like "B"), but there's no point in having multiple variables for the same purpose just for different files.