### PR TITLE
Revert "sched: ems/tune: use power efficient workingqueues"

### DIFF
--- a/kernel/sched/ems/tune.c
+++ b/kernel/sched/ems/tune.c
@@ -1942,7 +1942,7 @@ static void emstune_boot(void)
 	spin_unlock_irqrestore(&emstune_lock, flags);
 
 	INIT_DELAYED_WORK(&emstune.boot.work, emstune_boot_done);
-	queue_delayed_work(system_power_efficient_wq, &emstune.boot.work, msecs_to_jiffies(40000));
+	schedule_delayed_work(&emstune.boot.work, msecs_to_jiffies(40000));
 }
 
 static int emstune_mode_init(struct device_node *dn)


### PR DESCRIPTION
It results in slight lag so I don't think its worth it.