### PR TITLE
Partially revert "treewide: use power efficient workingqueues"

### DIFF
--- a/kernel/sched/psi.c
+++ b/kernel/sched/psi.c
@@ -448,7 +448,7 @@ static void psi_avgs_work(struct work_struct *work)
 		group->avg_next_update = update_averages(group, now);
 
 	if (nonidle) {
-		queue_delayed_work(system_power_efficient_wq, dwork, nsecs_to_jiffies(
+		schedule_delayed_work(dwork, nsecs_to_jiffies(
 				group->avg_next_update - now) + 1);
 	}
 
@@ -815,7 +815,7 @@ static void psi_group_change(struct psi_group *group, int cpu,
 		psi_schedule_poll_work(group, 1, false);
 
 	if (wake_clock && !delayed_work_pending(&group->avgs_work))
-		queue_delayed_work(system_power_efficient_wq, &group->avgs_work, PSI_FREQ);
+		schedule_delayed_work(&group->avgs_work, PSI_FREQ);
 }
 
 static struct psi_group *iterate_groups(struct task_struct *task, void **iter)


### PR DESCRIPTION
Since android relies on psi pressure very much, this seems to have been reducing performance. It looks like it was meant for an older android version because it performs much worse with it enabled.