### PR TITLE
Deprecate ml_cpu_util

### DIFF
--- a/include/trace/events/ems_debug.h
+++ b/include/trace/events/ems_debug.h
@@ -2048,7 +2048,7 @@ TRACE_EVENT(lb_cpu_util,
 		__entry->nr_running             = cpu_rq(cpu)->nr_running;
 		__entry->cfs_nr_running         = cpu_rq(cpu)->cfs.h_nr_running;
 		__entry->nr_misfits             = ems_rq_nr_misfited(cpu_rq(cpu));
-		__entry->cpu_util               = ml_cpu_util(cpu);
+		__entry->cpu_util               = cpu_util_cfs(cpu);
 		__entry->capacity_orig          = capacity_orig_of(cpu);
 		strncpy(__entry->label, label, 63);
 		),

--- a/kernel/sched/cpufreq_schedutil.c
+++ b/kernel/sched/cpufreq_schedutil.c
@@ -339,7 +339,7 @@ unsigned long sugov_effective_cpu_perf(int cpu, unsigned long actual,
 static void sugov_get_util(struct sugov_cpu *sg_cpu, unsigned long boost)
 {
 	struct rq *rq = cpu_rq(sg_cpu->cpu);
-	unsigned long min, max, util = cpu_util_cfs(rq);
+	unsigned long min, max, util = cpu_util_schedutil(rq);
 
 	util = schedutil_cpu_util(sg_cpu->cpu, util, &min, &max);
 	util = max(util, boost);

--- a/kernel/sched/ems/balance.c
+++ b/kernel/sched/ems/balance.c
@@ -191,7 +191,7 @@ static void lb_find_busiest_faster_queue(int dst_cpu,
 
 		trace_lb_cpu_util(src_cpu, "faster");
 
-		util = ml_cpu_util(src_cpu) + cpu_util_rt(src_rq);
+		util = cpu_util_cfs_boost(src_cpu) + cpu_util_rt(src_rq);
 		util_sum += util;
 		nr_task_sum += src_rq->cfs.h_nr_running;
 
@@ -242,7 +242,7 @@ static void lb_find_busiest_slower_queue(int dst_cpu,
 			!lb_queue_need_active_mgt(src_rq, cpu_rq(dst_cpu)))
 			continue;
 
-		util = ml_cpu_util(src_cpu) + cpu_util_rt(src_rq);
+		util = cpu_util_cfs_boost(src_cpu) + cpu_util_rt(src_rq);
 		if (util < busiest_util)
 			continue;
 
@@ -272,7 +272,7 @@ static void lb_find_busiest_equivalent_queue(int dst_cpu,
 			continue;
 
 		/* find highest util cpu */
-		util = ml_cpu_util(src_cpu) + cpu_util_rt(src_rq);
+		util = cpu_util_cfs_boost(src_cpu) + cpu_util_rt(src_rq);
 		if (util < busiest_util)
 			continue;
 

--- a/kernel/sched/ems/ecs.c
+++ b/kernel/sched/ems/ecs.c
@@ -152,7 +152,7 @@ static void move_from_spared_cpus(struct cpumask *spared_cpus)
 			struct rq *rq = cpu_rq(cpu);
 			int cpu_util;
 
-			cpu_util = ml_cpu_util(cpu) + cpu_util_rt(rq);
+			cpu_util = cpu_util_cfs(cpu) + cpu_util_rt(rq);
 			if (min_util < cpu_util)
 				continue;
 

--- a/kernel/sched/ems/ecs_dynamic.c
+++ b/kernel/sched/ems/ecs_dynamic.c
@@ -159,7 +159,7 @@ static void dynamic_enqueue_release_cpus(int prev_cpu, struct task_struct *p)
 
 	for_each_cpu(cpu, &domain->governor_cpus) {
 		struct rq *rq = cpu_rq(cpu);
-		int cpu_util = ml_cpu_util(cpu) + cpu_util_rt(rq) + cpu_util_dl(rq);
+		int cpu_util = cpu_util_cfs(cpu) + cpu_util_rt(rq) + cpu_util_dl(rq);
 
 		if (cpu_util > min_util)
 			continue;
@@ -282,7 +282,7 @@ static int update_domain_info(struct dynamic_dom *domain, int slower_misfit_cnt)
 		misfit += ems_rq_nr_misfited(rq);
 
 		/* 4. compute util */
-		util += (ml_cpu_util(cpu) + cpu_util_rt(rq));
+		util += (cpu_util_cfs(cpu) + cpu_util_rt(rq));
 
 		/* 5. compute average active ratio */
 		cur_ar = mlt_art_value(cpu, cur_idx);

--- a/kernel/sched/ems/ego.c
+++ b/kernel/sched/ems/ego.c
@@ -772,7 +772,7 @@ out:
 static unsigned long ego_get_util(struct ego_cpu *egc)
 {
 	struct rq *rq = cpu_rq(egc->cpu);
-	unsigned long util = ml_cpu_util(egc->cpu);
+	unsigned long util = cpu_util_cfs(egc->cpu);
 	unsigned long max = arch_scale_cpu_capacity(egc->cpu);
 
 	egc->max = max;

--- a/kernel/sched/ems/ems.h
+++ b/kernel/sched/ems/ems.h
@@ -322,7 +322,6 @@ extern void ntu_init(struct kobject *ems_kobj);
 extern unsigned long ml_task_util(struct task_struct *p);
 extern unsigned long ml_task_util_est(struct task_struct *p);
 extern unsigned long ml_task_load_avg(struct task_struct *p);
-extern unsigned long ml_cpu_util(int cpu);
 extern unsigned long ml_cpu_util_with(struct task_struct *p, int dst_cpu);
 extern unsigned long ml_cpu_util_without(int cpu, struct task_struct *p);
 extern unsigned long ml_cpu_load_avg(int cpu);
@@ -915,7 +914,7 @@ static inline unsigned long capacity_cpu(int cpu)
 
 static inline int cpu_overutilized(int cpu)
 {
-	return (capacity_cpu(cpu) * 1024) < (ml_cpu_util(cpu) * 1280);
+	return (capacity_cpu(cpu) * 1024) < (cpu_util_cfs(cpu) * 1280);
 }
 
 static inline struct task_struct *task_of(struct sched_entity *se)
@@ -1004,7 +1003,7 @@ static inline bool is_busy_cpu(int cpu)
 
 	cfs_rq = &cpu_rq(cpu)->cfs;
 
-	util = ml_cpu_util(cpu);
+	util = cpu_util_cfs(cpu);
 	runnable = READ_ONCE(cfs_rq->avg.runnable_avg);
 	capacity = capacity_orig_of(cpu);
 	nr_running = cpu_rq(cpu)->nr_running;

--- a/kernel/sched/ems/energy_step.c
+++ b/kernel/sched/ems/energy_step.c
@@ -978,7 +978,7 @@ static void esgov_update_cpu_util(struct esgov_policy *esg_policy, u64 time, uns
 		esg_cpu->io_util = esgov_iowait_apply(esg_cpu, time, max);
 
 		/* update sched_util */
-		esg_cpu->pelt_util = ml_cpu_util(cpu) + cpu_util_rt(rq);
+		esg_cpu->pelt_util = cpu_util_cfs(cpu) + cpu_util_rt(rq);
 
 		/* update step_util, If cpu is idle, we want to ignore step_util */
 		esg_cpu->step_util = esgov_get_step_util(esg_cpu, max);

--- a/kernel/sched/ems/frt.c
+++ b/kernel/sched/ems/frt.c
@@ -34,7 +34,7 @@ static u64 frt_cpu_util(int cpu)
 	struct rq *rq = cpu_rq(cpu);
 	u64 cpu_util;
 
-	cpu_util = ml_cpu_util(cpu);
+	cpu_util = cpu_util_cfs(cpu);
 	cpu_util += READ_ONCE(rq->avg_rt.util_avg) + READ_ONCE(rq->avg_dl.util_avg);
 
 	return cpu_util;

--- a/kernel/sched/ems/multi_load.c
+++ b/kernel/sched/ems/multi_load.c
@@ -60,22 +60,6 @@ unsigned long ml_task_load_avg(struct task_struct *p)
  *                            MULTI LOAD for CPU                              *
  ******************************************************************************/
 /*
- * ml_cpu_util - cpu utilization
- */
-unsigned long ml_cpu_util(int cpu)
-{
-	struct cfs_rq *cfs_rq;
-	unsigned int util;
-
-	cfs_rq = &cpu_rq(cpu)->cfs;
-	util = READ_ONCE(cfs_rq->avg.util_avg);
-
-	util = max(util, READ_ONCE(cfs_rq->avg.util_est.enqueued));
-
-	return min_t(unsigned long, util, capacity_cpu_orig(cpu));
-}
-
-/*
  * ml_cpu_util_est - return cpu util_est
  */
 unsigned long ml_cpu_util_est(int cpu)
@@ -110,7 +94,7 @@ unsigned long ml_cpu_util_without(int cpu, struct task_struct *p)
 
 	/* Task has no contribution or is new */
 	if (cpu != task_cpu(p) || !READ_ONCE(p->se.avg.last_update_time))
-		return ml_cpu_util(cpu);
+		return cpu_util_cfs(cpu);
 
 	cfs_rq = &cpu_rq(cpu)->cfs;
 

--- a/kernel/sched/ems/ontime.c
+++ b/kernel/sched/ems/ontime.c
@@ -343,7 +343,7 @@ static void ontime_heavy_migration(void)
 	 * No need to traverse rq to find a heavy task
 	 * if this CPU utilization is under upper boundary
 	 */
-	if (ml_cpu_util(cpu_of(rq)) < dom->upper_boundary)
+	if (cpu_util_cfs(cpu_of(rq)) < dom->upper_boundary)
 		return;
 
 	raw_spin_rq_lock_irqsave(rq, flags);
@@ -431,7 +431,7 @@ int ontime_can_migrate_task(struct task_struct *p, int dst_cpu)
 		 * (criteria : task util is under 75% of cpu util)
 		 */
 		if (cpu_overutilized(src_cpu) &&
-			util * 100 < (ml_cpu_util(src_cpu) * 75)) {
+			util * 100 < (cpu_util_cfs(src_cpu) * 75)) {
 			trace_ontime_can_migrate_task(p, dst_cpu, true, "src overutil");
 			return true;
 		}

--- a/kernel/sched/ems/profile.c
+++ b/kernel/sched/ems/profile.c
@@ -300,7 +300,7 @@ static void profile_update_cpu_util(int cpu, int *busy_cnt, unsigned long *util_
 	int cpu_util;
 	struct cpu_profile *cs = get_cpu_profile(cpu, CPU_UTIL);
 
-	cpu_util = ml_cpu_util(cpu) + cpu_util_rt(cpu_rq(cpu));
+	cpu_util = cpu_util_cfs(cpu) + cpu_util_rt(cpu_rq(cpu));
 	(*util_sum) += cpu_util;
 
 	if (check_busy(cpu_util, capacity_cpu(cpu))) {

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -6797,11 +6797,13 @@ unsigned long cpu_util_cfs(int cpu)
 {
 	return cpu_util(cpu, NULL, -1, 0);
 }
+EXPORT_SYMBOL_GPL(cpu_util_cfs);
 
 unsigned long cpu_util_cfs_boost(int cpu)
 {
 	return cpu_util(cpu, NULL, -1, 1);
 }
+EXPORT_SYMBOL_GPL(cpu_util_cfs_boost);
 
 /*
  * cpu_util_without: compute cpu utilization without any contributions from *p

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -6689,6 +6689,7 @@ static int select_idle_sibling(struct task_struct *p, int prev, int target)
  * @cpu: the CPU to get the utilization for
  * @p: task for which the CPU utilization should be predicted or NULL
  * @dst_cpu: CPU @p migrates to, -1 if @p moves from @cpu or @p == NULL
+ * @boost: 1 to enable boosting, otherwise 0
  *
  * The unit of the return value must be the same as the one of CPU capacity
  * so that CPU utilization can be compared with CPU capacity.
@@ -6706,6 +6707,12 @@ static int select_idle_sibling(struct task_struct *p, int prev, int target)
  * be when a long-sleeping task wakes up. The contribution to CPU utilization
  * of such a task would be significantly decayed at this point of time.
  *
+ * Boosted CPU utilization is defined as max(CPU runnable, CPU utilization).
+ * CPU contention for CFS tasks can be detected by CPU runnable > CPU
+ * utilization. Boosting is implemented in cpu_util() so that internal
+ * users (e.g. EAS) can use it next to external users (e.g. schedutil),
+ * latter via cpu_util_cfs_boost().
+ *
  * CPU utilization can be higher than the current CPU capacity
  * (f_curr/f_max * max CPU capacity) or even the max CPU capacity because
  * of rounding errors as well as task migrations or wakeups of new tasks.
@@ -6716,12 +6723,19 @@ static int select_idle_sibling(struct task_struct *p, int prev, int target)
  * though since this is useful for predicting the CPU capacity required
  * after task migrations (scheduler-driven DVFS).
  *
- * Return: (Estimated) utilization for the specified CPU.
+ * Return: (Boosted) (estimated) utilization for the specified CPU.
  */
-static unsigned long cpu_util(int cpu, struct task_struct *p, int dst_cpu)
+static unsigned long
+cpu_util(int cpu, struct task_struct *p, int dst_cpu, int boost)
 {
 	struct cfs_rq *cfs_rq = &cpu_rq(cpu)->cfs;
 	unsigned long util = READ_ONCE(cfs_rq->avg.util_avg);
+	unsigned long runnable;
+
+	if (boost) {
+		runnable = READ_ONCE(cfs_rq->avg.runnable_avg);
+		util = max(util, runnable);
+	}
 
 	/*
 	 * If @dst_cpu is -1 or @p migrates from @cpu to @dst_cpu remove its
@@ -6738,6 +6752,9 @@ static unsigned long cpu_util(int cpu, struct task_struct *p, int dst_cpu)
 		unsigned long util_est;
 
 		util_est = READ_ONCE(cfs_rq->avg.util_est.enqueued);
+
+		if (boost)
+			util_est = max(util_est, runnable);
 
 		/*
 		 * During wake-up @p isn't enqueued yet and doesn't contribute
@@ -6778,7 +6795,12 @@ static unsigned long cpu_util(int cpu, struct task_struct *p, int dst_cpu)
 
 unsigned long cpu_util_cfs(int cpu)
 {
-	return cpu_util(cpu, NULL, -1);
+	return cpu_util(cpu, NULL, -1, 0);
+}
+
+unsigned long cpu_util_cfs_boost(int cpu)
+{
+	return cpu_util(cpu, NULL, -1, 1);
 }
 
 /*
@@ -6800,7 +6822,7 @@ static unsigned long cpu_util_without(int cpu, struct task_struct *p)
 	if (cpu != task_cpu(p) || !READ_ONCE(p->se.avg.last_update_time))
 		p = NULL;
 
-	return cpu_util(cpu, p, -1);
+	return cpu_util(cpu, p, -1, 0);
 }
 
 /*
@@ -6829,7 +6851,7 @@ compute_energy(struct task_struct *p, int dst_cpu, struct perf_domain *pd)
 	 * its pd list and will not be accounted by compute_energy().
 	 */
 	for_each_cpu_and(cpu, pd_mask, cpu_online_mask) {
-		unsigned long util, util_cfs = cpu_util(cpu, p, dst_cpu);
+		unsigned long util, util_cfs = cpu_util(cpu, p, dst_cpu, 0);
 		struct task_struct *tsk = cpu == dst_cpu ? p : NULL;
 		unsigned long min, max;
 
@@ -6983,7 +7005,7 @@ static int find_energy_efficient_cpu(struct task_struct *p, int prev_cpu, int sy
 			if (!cpumask_test_cpu(cpu, p->cpus_ptr))
 				continue;
 
-			util = cpu_util(cpu, p, cpu);
+			util = cpu_util(cpu, p, cpu, 0);
 			cpu_cap = capacity_of(cpu);
 			spare_cap = cpu_cap;
 			lsub_positive(&spare_cap, util);
@@ -9803,7 +9825,7 @@ static struct rq *find_busiest_queue(struct lb_env *env,
 			break;
 
 		case migrate_util:
-			util = cpu_util(cpu_of(rq));
+			util = cpu_util_cfs_boost(cpu_of(rq));
 
 			/*
 			 * Don't try to pull utilization from a CPU with one

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -6841,7 +6841,7 @@ static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
 	 * util_avg should already be correct.
 	 */
 	if (task_cpu(p) == cpu && dst_cpu != cpu)
-		sub_positive(&util, task_util(p));
+		lsub_positive(&util, task_util(p));
 	else if (task_cpu(p) != cpu && dst_cpu == cpu)
 		util += task_util(p);
 

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -5786,7 +5786,7 @@ static inline void hrtick_update(struct rq *rq)
 #endif
 
 #ifdef CONFIG_SMP
-static inline unsigned long cpu_util(int cpu);
+static unsigned long cpu_util(int cpu, struct task_struct *p, int dst_cpu, int boost);
 
 static inline bool cpu_overutilized(int cpu)
 {
@@ -5798,7 +5798,7 @@ static inline bool cpu_overutilized(int cpu)
 	if (overutilized != -1)
 		return overutilized;
 
-	return !util_fits_cpu(cpu_util(cpu), rq_util_min, rq_util_max, cpu);
+	return !util_fits_cpu(cpu_util_cfs(cpu), rq_util_min, rq_util_max, cpu);
 }
 
 static inline void update_overutilized_status(struct rq *rq)
@@ -6685,62 +6685,40 @@ static int select_idle_sibling(struct task_struct *p, int prev, int target)
 }
 
 /**
- * Amount of capacity of a CPU that is (estimated to be) used by CFS tasks
- * @cpu: the CPU to get the utilization of
+ * cpu_util() - Estimates the amount of CPU capacity used by CFS tasks.
+ * @cpu: the CPU to get the utilization for
+ * @p: task for which the CPU utilization should be predicted or NULL
+ * @dst_cpu: CPU @p migrates to, -1 if @p moves from @cpu or @p == NULL
  *
- * The unit of the return value must be the one of capacity so we can compare
- * the utilization with the capacity of the CPU that is available for CFS task
- * (ie cpu_capacity).
+ * The unit of the return value must be the same as the one of CPU capacity
+ * so that CPU utilization can be compared with CPU capacity.
  *
- * cfs_rq.avg.util_avg is the sum of running time of runnable tasks plus the
- * recent utilization of currently non-runnable tasks on a CPU. It represents
- * the amount of utilization of a CPU in the range [0..capacity_orig] where
- * capacity_orig is the cpu_capacity available at the highest frequency
- * (arch_scale_freq_capacity()).
- * The utilization of a CPU converges towards a sum equal to or less than the
- * current capacity (capacity_curr <= capacity_orig) of the CPU because it is
- * the running time on this CPU scaled by capacity_curr.
+ * CPU utilization is the sum of running time of runnable tasks plus the
+ * recent utilization of currently non-runnable tasks on that CPU.
+ * It represents the amount of CPU capacity currently used by CFS tasks in
+ * the range [0..max CPU capacity] with max CPU capacity being the CPU
+ * capacity at f_max.
  *
- * The estimated utilization of a CPU is defined to be the maximum between its
- * cfs_rq.avg.util_avg and the sum of the estimated utilization of the tasks
- * currently RUNNABLE on that CPU.
- * This allows to properly represent the expected utilization of a CPU which
- * has just got a big task running since a long sleep period. At the same time
- * however it preserves the benefits of the "blocked utilization" in
- * describing the potential for other tasks waking up on the same CPU.
+ * The estimated CPU utilization is defined as the maximum between CPU
+ * utilization and sum of the estimated utilization of the currently
+ * runnable tasks on that CPU. It preserves a utilization "snapshot" of
+ * previously-executed tasks, which helps better deduce how busy a CPU will
+ * be when a long-sleeping task wakes up. The contribution to CPU utilization
+ * of such a task would be significantly decayed at this point of time.
  *
- * Nevertheless, cfs_rq.avg.util_avg can be higher than capacity_curr or even
- * higher than capacity_orig because of unfortunate rounding in
- * cfs.avg.util_avg or just after migrating tasks and new task wakeups until
- * the average stabilizes with the new running time. We need to check that the
- * utilization stays within the range of [0..capacity_orig] and cap it if
- * necessary. Without utilization capping, a group could be seen as overloaded
- * (CPU0 utilization at 121% + CPU1 utilization at 80%) whereas CPU1 has 20% of
- * available capacity. We allow utilization to overshoot capacity_curr (but not
- * capacity_orig) as it useful for predicting the capacity required after task
- * migrations (scheduler-driven DVFS).
+ * CPU utilization can be higher than the current CPU capacity
+ * (f_curr/f_max * max CPU capacity) or even the max CPU capacity because
+ * of rounding errors as well as task migrations or wakeups of new tasks.
+ * CPU utilization has to be capped to fit into the [0..max CPU capacity]
+ * range. Otherwise a group of CPUs (CPU0 util = 121% + CPU1 util = 80%)
+ * could be seen as over-utilized even though CPU1 has 20% of spare CPU
+ * capacity. CPU utilization is allowed to overshoot current CPU capacity
+ * though since this is useful for predicting the CPU capacity required
+ * after task migrations (scheduler-driven DVFS).
  *
- * Return: the (estimated) utilization for the specified CPU
+ * Return: (Estimated) utilization for the specified CPU.
  */
-static inline unsigned long cpu_util(int cpu)
-{
-	struct cfs_rq *cfs_rq;
-	unsigned int util;
-
-	cfs_rq = &cpu_rq(cpu)->cfs;
-	util = READ_ONCE(cfs_rq->avg.util_avg);
-
-	if (sched_feat(UTIL_EST))
-		util = max(util, READ_ONCE(cfs_rq->avg.util_est.enqueued));
-
-	return min_t(unsigned long, util, capacity_orig_of(cpu));
-}
-
-/*
- * Predicts what cpu_util(@cpu) would return if @p was removed from @cpu
- * (@dst_cpu = -1) or migrated to @dst_cpu.
- */
-static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
+static unsigned long cpu_util(int cpu, struct task_struct *p, int dst_cpu)
 {
 	struct cfs_rq *cfs_rq = &cpu_rq(cpu)->cfs;
 	unsigned long util = READ_ONCE(cfs_rq->avg.util_avg);
@@ -6751,9 +6729,9 @@ static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
 	 * contribution. In all the other cases @cpu is not impacted by the
 	 * migration so its util_avg is already correct.
 	 */
-	if (task_cpu(p) == cpu && dst_cpu != cpu)
+	if (p && task_cpu(p) == cpu && dst_cpu != cpu)
 		lsub_positive(&util, task_util(p));
-	else if (task_cpu(p) != cpu && dst_cpu == cpu)
+	else if (p && task_cpu(p) != cpu && dst_cpu == cpu)
 		util += task_util(p);
 
 	if (sched_feat(UTIL_EST)) {
@@ -6789,13 +6767,18 @@ static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
 		 */
 		if (dst_cpu == cpu)
 			util_est += _task_util_est(p);
-		else if (unlikely(task_on_rq_queued(p) || current == p))
+		else if (p && unlikely(task_on_rq_queued(p) || current == p))
 			lsub_positive(&util_est, _task_util_est(p));
 
 		util = max(util, util_est);
 	}
 
 	return min(util, capacity_orig_of(cpu));
+}
+
+unsigned long cpu_util_cfs(int cpu)
+{
+	return cpu_util(cpu, NULL, -1);
 }
 
 /*
@@ -6815,9 +6798,9 @@ static unsigned long cpu_util_without(int cpu, struct task_struct *p)
 {
 	/* Task has no contribution or is new */
 	if (cpu != task_cpu(p) || !READ_ONCE(p->se.avg.last_update_time))
-		return cpu_util(cpu);
+		p = NULL;
 
-	return cpu_util_next(cpu, p, -1);
+	return cpu_util(cpu, p, -1);
 }
 
 /*
@@ -6846,7 +6829,7 @@ compute_energy(struct task_struct *p, int dst_cpu, struct perf_domain *pd)
 	 * its pd list and will not be accounted by compute_energy().
 	 */
 	for_each_cpu_and(cpu, pd_mask, cpu_online_mask) {
-		unsigned long cpu_util, util_cfs = cpu_util_next(cpu, p, dst_cpu);
+		unsigned long util, util_cfs = cpu_util(cpu, p, dst_cpu);
 		struct task_struct *tsk = cpu == dst_cpu ? p : NULL;
 		unsigned long min, max;
 
@@ -6865,7 +6848,7 @@ compute_energy(struct task_struct *p, int dst_cpu, struct perf_domain *pd)
 		 * NOTE: in case RT tasks are running, by default the
 		 * FREQUENCY_UTIL's utilization can be max OPP.
 		 */
-		cpu_util = schedutil_cpu_util(cpu, util_cfs, &min, &max);
+		util = schedutil_cpu_util(cpu, util_cfs, &min, &max);
 
 		/* Task's uclamp can modify min and max value */
 		if (tsk && uclamp_is_used()) {
@@ -6881,8 +6864,8 @@ compute_energy(struct task_struct *p, int dst_cpu, struct perf_domain *pd)
 				max = max(max, uclamp_eff_value(p, UCLAMP_MAX));
 		}
 
-		cpu_util = sugov_effective_cpu_perf(cpu, cpu_util, min, max);
-		max_util = max(max_util, cpu_util);
+		util = sugov_effective_cpu_perf(cpu, util, min, max);
+		max_util = max(max_util, util);
 	}
 
 	trace_android_vh_em_cpu_energy(pd->em_pd, max_util, sum_util, &energy);
@@ -7000,7 +6983,7 @@ static int find_energy_efficient_cpu(struct task_struct *p, int prev_cpu, int sy
 			if (!cpumask_test_cpu(cpu, p->cpus_ptr))
 				continue;
 
-			util = cpu_util_next(cpu, p, cpu);
+			util = cpu_util(cpu, p, cpu);
 			cpu_cap = capacity_of(cpu);
 			spare_cap = cpu_cap;
 			lsub_positive(&spare_cap, util);
@@ -8817,7 +8800,7 @@ static inline void update_sg_lb_stats(struct lb_env *env,
 		struct rq *rq = cpu_rq(i);
 
 		sgs->group_load += cpu_load(rq);
-		sgs->group_util += cpu_util(i);
+		sgs->group_util += cpu_util_cfs(i);
 		sgs->group_runnable += cpu_runnable(rq);
 		sgs->sum_h_nr_running += rq->cfs.h_nr_running;
 

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -6737,6 +6737,68 @@ static inline unsigned long cpu_util(int cpu)
 }
 
 /*
+ * Predicts what cpu_util(@cpu) would return if @p was removed from @cpu
+ * (@dst_cpu = -1) or migrated to @dst_cpu.
+ */
+static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
+{
+	struct cfs_rq *cfs_rq = &cpu_rq(cpu)->cfs;
+	unsigned long util = READ_ONCE(cfs_rq->avg.util_avg);
+
+	/*
+	 * If @dst_cpu is -1 or @p migrates from @cpu to @dst_cpu remove its
+	 * contribution. If @p migrates from another CPU to @cpu add its
+	 * contribution. In all the other cases @cpu is not impacted by the
+	 * migration so its util_avg is already correct.
+	 */
+	if (task_cpu(p) == cpu && dst_cpu != cpu)
+		lsub_positive(&util, task_util(p));
+	else if (task_cpu(p) != cpu && dst_cpu == cpu)
+		util += task_util(p);
+
+	if (sched_feat(UTIL_EST)) {
+		unsigned long util_est;
+
+		util_est = READ_ONCE(cfs_rq->avg.util_est.enqueued);
+
+		/*
+		 * During wake-up @p isn't enqueued yet and doesn't contribute
+		 * to any cpu_rq(cpu)->cfs.avg.util_est.enqueued.
+		 * If @dst_cpu == @cpu add it to "simulate" cpu_util after @p
+		 * has been enqueued.
+		 *
+		 * During exec (@dst_cpu = -1) @p is enqueued and does
+		 * contribute to cpu_rq(cpu)->cfs.util_est.enqueued.
+		 * Remove it to "simulate" cpu_util without @p's contribution.
+		 *
+		 * Despite the task_on_rq_queued(@p) check there is still a
+		 * small window for a possible race when an exec
+		 * select_task_rq_fair() races with LB's detach_task().
+		 *
+		 *   detach_task()
+		 *     deactivate_task()
+		 *       p->on_rq = TASK_ON_RQ_MIGRATING;
+		 *       -------------------------------- A
+		 *       dequeue_task()                    \
+		 *         dequeue_task_fair()              + Race Time
+		 *           util_est_dequeue()            /
+		 *       -------------------------------- B
+		 *
+		 * The additional check "current == p" is required to further
+		 * reduce the race window.
+		 */
+		if (dst_cpu == cpu)
+			util_est += _task_util_est(p);
+		else if (unlikely(task_on_rq_queued(p) || current == p))
+			lsub_positive(&util_est, _task_util_est(p));
+
+		util = max(util, util_est);
+	}
+
+	return min(util, capacity_orig_of(cpu));
+}
+
+/*
  * cpu_util_without: compute cpu utilization without any contributions from *p
  * @cpu: the CPU which utilization is requested
  * @p: the task which utilization should be discounted
@@ -6751,116 +6813,11 @@ static inline unsigned long cpu_util(int cpu)
  */
 static unsigned long cpu_util_without(int cpu, struct task_struct *p)
 {
-	struct cfs_rq *cfs_rq;
-	unsigned int util;
-
 	/* Task has no contribution or is new */
 	if (cpu != task_cpu(p) || !READ_ONCE(p->se.avg.last_update_time))
 		return cpu_util(cpu);
 
-	cfs_rq = &cpu_rq(cpu)->cfs;
-	util = READ_ONCE(cfs_rq->avg.util_avg);
-
-	/* Discount task's util from CPU's util */
-	lsub_positive(&util, task_util(p));
-
-	/*
-	 * Covered cases:
-	 *
-	 * a) if *p is the only task sleeping on this CPU, then:
-	 *      cpu_util (== task_util) > util_est (== 0)
-	 *    and thus we return:
-	 *      cpu_util_without = (cpu_util - task_util) = 0
-	 *
-	 * b) if other tasks are SLEEPING on this CPU, which is now exiting
-	 *    IDLE, then:
-	 *      cpu_util >= task_util
-	 *      cpu_util > util_est (== 0)
-	 *    and thus we discount *p's blocked utilization to return:
-	 *      cpu_util_without = (cpu_util - task_util) >= 0
-	 *
-	 * c) if other tasks are RUNNABLE on that CPU and
-	 *      util_est > cpu_util
-	 *    then we use util_est since it returns a more restrictive
-	 *    estimation of the spare capacity on that CPU, by just
-	 *    considering the expected utilization of tasks already
-	 *    runnable on that CPU.
-	 *
-	 * Cases a) and b) are covered by the above code, while case c) is
-	 * covered by the following code when estimated utilization is
-	 * enabled.
-	 */
-	if (sched_feat(UTIL_EST)) {
-		unsigned int estimated =
-			READ_ONCE(cfs_rq->avg.util_est.enqueued);
-
-		/*
-		 * Despite the following checks we still have a small window
-		 * for a possible race, when an execl's select_task_rq_fair()
-		 * races with LB's detach_task():
-		 *
-		 *   detach_task()
-		 *     p->on_rq = TASK_ON_RQ_MIGRATING;
-		 *     ---------------------------------- A
-		 *     deactivate_task()                   \
-		 *       dequeue_task()                     + RaceTime
-		 *         util_est_dequeue()              /
-		 *     ---------------------------------- B
-		 *
-		 * The additional check on "current == p" it's required to
-		 * properly fix the execl regression and it helps in further
-		 * reducing the chances for the above race.
-		 */
-		if (unlikely(task_on_rq_queued(p) || current == p))
-			lsub_positive(&estimated, _task_util_est(p));
-
-		util = max(util, estimated);
-	}
-
-	/*
-	 * Utilization (estimated) can exceed the CPU capacity, thus let's
-	 * clamp to the maximum CPU capacity to ensure consistency with
-	 * the cpu_util call.
-	 */
-	return min_t(unsigned long, util, capacity_orig_of(cpu));
-}
-
-/*
- * Predicts what cpu_util(@cpu) would return if @p was migrated (and enqueued)
- * to @dst_cpu.
- */
-static unsigned long cpu_util_next(int cpu, struct task_struct *p, int dst_cpu)
-{
-	struct cfs_rq *cfs_rq = &cpu_rq(cpu)->cfs;
-	unsigned long util_est, util = READ_ONCE(cfs_rq->avg.util_avg);
-
-	/*
-	 * If @p migrates from @cpu to another, remove its contribution. Or,
-	 * if @p migrates from another CPU to @cpu, add its contribution. In
-	 * the other cases, @cpu is not impacted by the migration, so the
-	 * util_avg should already be correct.
-	 */
-	if (task_cpu(p) == cpu && dst_cpu != cpu)
-		lsub_positive(&util, task_util(p));
-	else if (task_cpu(p) != cpu && dst_cpu == cpu)
-		util += task_util(p);
-
-	if (sched_feat(UTIL_EST)) {
-		util_est = READ_ONCE(cfs_rq->avg.util_est.enqueued);
-
-		/*
-		 * During wake-up, the task isn't enqueued yet and doesn't
-		 * appear in the cfs_rq->avg.util_est.enqueued of any rq,
-		 * so just add it (if needed) to "simulate" what will be
-		 * cpu_util() after the task has been enqueued.
-		 */
-		if (dst_cpu == cpu)
-			util_est += _task_util_est(p);
-
-		util = max(util, util_est);
-	}
-
-	return min(util, capacity_orig_of(cpu));
+	return cpu_util_next(cpu, p, -1);
 }
 
 /*

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -2692,7 +2692,7 @@ static inline unsigned long cpu_util_dl(struct rq *rq)
 	return READ_ONCE(rq->avg_dl.util_avg);
 }
 
-static inline unsigned long cpu_util_cfs(struct rq *rq)
+static inline unsigned long cpu_util_schedutil(struct rq *rq)
 {
 	unsigned long util = READ_ONCE(rq->cfs.avg.util_avg);
 

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -2483,6 +2483,7 @@ static inline void cpufreq_update_util(struct rq *rq, unsigned int flags) {}
 #endif /* CONFIG_CPU_FREQ */
 
 extern unsigned long cpu_util_cfs(int cpu);
+extern unsigned long cpu_util_cfs_boost(int cpu);
 
 #ifdef CONFIG_UCLAMP_TASK
 unsigned long uclamp_eff_value(struct task_struct *p, enum uclamp_id clamp_id);
@@ -2697,6 +2698,9 @@ static inline unsigned long cpu_util_dl(struct rq *rq)
 static inline unsigned long cpu_util_schedutil(struct rq *rq)
 {
 	unsigned long util = READ_ONCE(rq->cfs.avg.util_avg);
+	unsigned long runnable = READ_ONCE(rq->cfs.avg.runnable_avg);
+
+	util = max(util, runnable);
 
 	if (sched_feat(UTIL_EST)) {
 		util = max_t(unsigned long, util,

--- a/kernel/sched/sched.h
+++ b/kernel/sched/sched.h
@@ -2482,6 +2482,8 @@ static inline void cpufreq_update_util(struct rq *rq, unsigned int flags)
 static inline void cpufreq_update_util(struct rq *rq, unsigned int flags) {}
 #endif /* CONFIG_CPU_FREQ */
 
+extern unsigned long cpu_util_cfs(int cpu);
+
 #ifdef CONFIG_UCLAMP_TASK
 unsigned long uclamp_eff_value(struct task_struct *p, enum uclamp_id clamp_id);
 


### PR DESCRIPTION
There is alot of duplicated code in EMS scheduler and it causes noticeable lag so this improves performance significantly from my testing. It required a bit of upstreaming but its mostly removing duplicated code.